### PR TITLE
fixed setup.py (missing nettcp.stream)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(name='nettcp',
       author='Timo Schmid',
       author_email='tschmid@ernw.de',
       url='https://www.insinuator.net/?p=7513',
-      packages=['nettcp'],
+      packages=['nettcp', 'nettcp.stream'],
       scripts=[
         'scripts/decode-nmf.py',
         'scripts/decode-wcfbin.py',


### PR DESCRIPTION
Hi, thx for this! Unfortunately, your setup.py was missing 'nettcp.stream', thus breaking the install. This trivial change should fix it.