### PR TITLE
Wrap oversized GSSAPI payloads correctly

### DIFF
--- a/nettcp/stream/gssapi.py
+++ b/nettcp/stream/gssapi.py
@@ -42,8 +42,11 @@ class GSSAPIStream:
         if not self.client_ctx:
             self.negotiate()
 
-        data = self.client_ctx.encrypt(data)
-        self._inner.write(data)
+        while data:
+            data2 = data[:0xFC00]
+            e_data = self.client_ctx.encrypt(data2)
+            self._inner.write(e_data)
+            data = data[0xFC00:]
 
     def read(self, count=None):
         if not self.client_ctx:

--- a/nettcp/stream/negotiate.py
+++ b/nettcp/stream/negotiate.py
@@ -57,9 +57,10 @@ class NegotiateStream:
             self._inner.write(handshake + data)
         else:
             while data:
-                data2 = data[:0xFC00]
+                # See [MS-NNS] 2.2.2 Data Message v8.0 for length
+                data2 = data[:0xFC30]
                 self._inner.write(struct.pack('<I', len(data2)) + data2)
-                data = data[0xFC00:]
+                data = data[0xFC30:]
 
     def read(self, count=None):
         if not self._handshake_done:


### PR DESCRIPTION
The original [MS-NNS] specification incorrectly noted the max length of
negotiate stream packets as 0xFC00, when this was max length of the
pre-wrapped data. The original code also did not GSSAPI wrap in chunks.

Wrapping each chunk adds a header of up to 0x30, which has now been
corrected in the upstream specification.

https://lists.samba.org/archive/cifs-protocol/2018-December/003195.html

(Note: There may also need to be a correction on the read side.)