### PR TITLE
Catch OSError from GSSAPI when Kerberos support is missing on Windows

### DIFF
--- a/nettcp/proxy.py
+++ b/nettcp/proxy.py
@@ -20,7 +20,7 @@ from .nmf import (Record, EndRecord, KnownEncodingRecord,
                   UpgradeRequestRecord, UpgradeResponseRecord, register_types)
 try:
     from .stream.gssapi import GSSAPIStream
-except ImportError:
+except (ImportError, OSError):
     warnings.warn('gssapi not installed, no negotiate protocol available')
     GSSAPIStream = None
 


### PR DESCRIPTION
Here is the full stack trace of the OSError we want to skip:
```
Traceback (most recent call last):
  File "...\net.tcp-proxy/scripts/nettcp-proxy.py", line 3, in <module>
    from nettcp.proxy import main
  File "...\net.tcp-proxy\nettcp\proxy.py", line 22, in <module>
    from .stream.gssapi import GSSAPIStream
  File "...\net.tcp-proxy\nettcp\stream\gssapi.py", line 7, in <module>
    import gssapi
  File "C:\Program Files\Python37\lib\site-packages\gssapi\__init__.py", line 29, in <module>
    import gssapi._win_config  # noqa
  File "C:\Program Files\Python37\lib\site-packages\gssapi\_win_config.py", line 74, in <module>
    configure_windows()
  File "C:\Program Files\Python37\lib\site-packages\gssapi\_win_config.py", line 70, in configure_windows
    error_not_found()
  File "C:\Program Files\Python37\lib\site-packages\gssapi\_win_config.py", line 38, in error_not_found
    % (KFW_DL, KFW_BIN)
OSError: Could not find KfW installation. Please download and install the 64bit Kerberos for Windows MSI from https://web.mit.edu/KERBEROS/dist and ensure the 'bin' folder (C:\Program Files\MIT\Kerberos\bin) is in your PATH.
```